### PR TITLE
Fixed if using cursor and there wasn't a line break after final number, the cursor would go before the final number

### DIFF
--- a/RichTextVC-iOS.podspec
+++ b/RichTextVC-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RichTextVC-iOS"
-  s.version          = "1.3.0"
+  s.version          = "1.3.1"
   s.summary          = "A Rich Text ViewController for iOS."
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Fixed being able to continue numbers from a previous line
Fixed getting the whole number. It was sometimes only returning one digit
Worked on more issues with lists not formatting properly
