### PR TITLE
Fix crash with mismatched begin and end editing calls.

### DIFF
--- a/RichTextVC-iOS.podspec
+++ b/RichTextVC-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RichTextVC-iOS"
-  s.version          = "2.0.2"
+  s.version          = "2.0.3"
   s.summary          = "A Rich Text ViewController for iOS."
 
 # This description is used to generate tags and improve search results.

--- a/src/Classes/RichTextViewController.swift
+++ b/src/Classes/RichTextViewController.swift
@@ -352,13 +352,13 @@ open class RichTextViewController: UIViewController {
             let previousRange = NSRange(location: range.location - RichTextViewController.bulletedLineStarter.length, length: RichTextViewController.bulletedLineStarter.length)
             let bulletedString = "\n" + RichTextViewController.bulletedLineStarter
             
-            textView.textStorage.beginEditing()
             if let subString = textView.attributedText?.attributedSubstring(from: previousRange).string, subString == RichTextViewController.bulletedLineStarter {
+                textView.textStorage.beginEditing()
                 textView.textStorage.replaceCharacters(in: previousRange, with: NSAttributedString(string: "", attributes: textView.typingAttributes))
+                textView.textStorage.endEditing()
             } else {
                 addText(bulletedString, toTextView: textView, atIndex: range.location)
             }
-            textView.textStorage.endEditing()
             textView.selectedRange = NSRange(location: range.location + (bulletedString as NSString).length, length: 0)
             
             return true


### PR DESCRIPTION
`addText` in the `else` branch has its own begin/end editing calls,
plus other stuff that shouldn't happen before `endEditing` is called.