### PR TITLE
GLI-3405& GLI-3406

### DIFF
--- a/RichTextVC-iOS.podspec
+++ b/RichTextVC-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RichTextVC-iOS"
-  s.version          = "2.0.3"
+  s.version          = "2.0.4"
   s.summary          = "A Rich Text ViewController for iOS."
 
 # This description is used to generate tags and improve search results.

--- a/src/Classes/RichTextViewController.swift
+++ b/src/Classes/RichTextViewController.swift
@@ -767,7 +767,7 @@ extension RichTextViewController: UITextViewDelegate {
     func textChanged(_ notification: Notification) {
         guard notification.object as? UITextView == textView else { return }
 
-        if let typingAttributes = previousTypingAttributes { textView.typingAttributes = attributes }
+        if let typingAttributes = previousTypingAttributes { textView.typingAttributes = typingAttributes }
 
         if textView.selectedRange.endLocation == textView.text.length {
             textView.typingAttributes[NSParagraphStyleAttributeName] = defaultParagraphStyle

--- a/src/Classes/RichTextViewController.swift
+++ b/src/Classes/RichTextViewController.swift
@@ -28,7 +28,9 @@ open class RichTextViewController: UIViewController {
 
     fileprivate var disableBold = false
     fileprivate var disableItalic = false
-    
+
+    fileprivate var previousTypingAttributes: [String: Any]?
+
     fileprivate var defaultParagraphStyle: NSParagraphStyle = {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.firstLineHeadIndent = 0
@@ -46,7 +48,10 @@ open class RichTextViewController: UIViewController {
     fileprivate var defaultListAttributes: [String: Any]? {
         guard let regularFont = regularFont else { return nil }
         
-        return [NSFontAttributeName: regularFont, NSParagraphStyleAttributeName: defaultListParagraphStyle]
+        var listAttributes: [String : Any] = [NSFontAttributeName: regularFont, NSParagraphStyleAttributeName: defaultListParagraphStyle]
+        if let textColor = textView.typingAttributes[NSForegroundColorAttributeName] { listAttributes[NSForegroundColorAttributeName] = textColor }
+
+        return listAttributes
     }
 
     deinit {
@@ -130,7 +135,7 @@ open class RichTextViewController: UIViewController {
     /// - parameter atIndex: The index to insert the text at.
     /// - parameter withAttributes: Optional.  Attributes to apply to the added text.  Will use attributes at the index otherwise.
     fileprivate func addText(_ text: String, toTextView textView: UITextView, atIndex index: Int) {
-        let previousTypingAttributes = textView.typingAttributes
+        previousTypingAttributes = textView.typingAttributes
         
         let attributes = defaultListAttributes ?? (index < textView.text.length ? textView.attributedText.attributes(at: index, effectiveRange: nil) : textView.typingAttributes)
         textView.textStorage.beginEditing()
@@ -143,7 +148,7 @@ open class RichTextViewController: UIViewController {
             textView.selectedRange.location += text.length
         }
         
-        textView.typingAttributes = previousTypingAttributes
+        textView.typingAttributes = previousTypingAttributes ?? textView.typingAttributes
         textViewDidChangeSelection(textView)
     }
 
@@ -744,7 +749,9 @@ extension RichTextViewController: UITextViewDelegate {
     
     open func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         var changed = false
-        
+
+        previousTypingAttributes = textView.typingAttributes
+
         switch text {
         case "\n":
             changed = addedListsIfActiveInRange(range)
@@ -759,7 +766,9 @@ extension RichTextViewController: UITextViewDelegate {
     
     func textChanged(_ notification: Notification) {
         guard notification.object as? UITextView == textView else { return }
-        
+
+        if let typingAttributes = previousTypingAttributes { textView.typingAttributes = attributes }
+
         if textView.selectedRange.endLocation == textView.text.length {
             textView.typingAttributes[NSParagraphStyleAttributeName] = defaultParagraphStyle
         }


### PR DESCRIPTION
Added the text color to defaultListAttributes so bullets/numbers in lists match the rest of the themed text, Made more use of previousTypingAttributes to fix an issue introduced in iOS11 where the attributes are reset as additional characters are typed.