### PR TITLE
fixed Bold/italic formatting only works single letter/word (ios11)

### DIFF
--- a/RichTextVC-iOS.podspec
+++ b/RichTextVC-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RichTextVC-iOS"
-  s.version          = "2.0.4"
+  s.version          = "2.0.5"
   s.summary          = "A Rich Text ViewController for iOS."
 
 # This description is used to generate tags and improve search results.

--- a/src/Classes/RichTextViewController.swift
+++ b/src/Classes/RichTextViewController.swift
@@ -582,7 +582,15 @@ open class RichTextViewController: UIViewController {
     open func selectionContainsBold(_ range: NSRange) -> Bool {
         guard !disableBold else { return false }
         
-        var font = range.length == 0 ? textView.typingAttributes[NSFontAttributeName] as? UIFont : nil
+        var font: UIFont?
+        if range.length == 0 {
+            if let previousTypingAttributes = previousTypingAttributes, range.endLocation == textView.text.length {
+                font = previousTypingAttributes[NSFontAttributeName] as? UIFont
+            } else {
+                font = textView.typingAttributes[NSFontAttributeName] as? UIFont
+            }
+        }
+        
         textView.attributedText.enumerateAttributes(in: range, options: []) { dictionary, _, _ in
             font = font ?? dictionary[NSFontAttributeName] as? UIFont
         }
@@ -613,7 +621,15 @@ open class RichTextViewController: UIViewController {
     open func selectionContainsItalic(_ range: NSRange) -> Bool {
         guard !disableItalic else { return false }
         
-        var font = range.length == 0 ? textView.typingAttributes[NSFontAttributeName] as? UIFont : nil
+        var font: UIFont?
+        if range.length == 0 {
+            if let previousTypingAttributes = previousTypingAttributes, range.endLocation == textView.text.length {
+                font = previousTypingAttributes[NSFontAttributeName] as? UIFont
+            } else {
+                font = textView.typingAttributes[NSFontAttributeName] as? UIFont
+            }
+        }
+        
         textView.attributedText.enumerateAttributes(in: range, options: []) { dictionary, _, _ in
             font = font ?? dictionary[NSFontAttributeName] as? UIFont
         }
@@ -768,10 +784,6 @@ extension RichTextViewController: UITextViewDelegate {
         guard notification.object as? UITextView == textView else { return }
 
         if let typingAttributes = previousTypingAttributes { textView.typingAttributes = typingAttributes }
-
-        if textView.selectedRange.endLocation == textView.text.length {
-            textView.typingAttributes[NSParagraphStyleAttributeName] = defaultParagraphStyle
-        }
     }
     
 }


### PR DESCRIPTION
previousTypingAttributes need to be applied to the text before the text is changed (instead of after). This will allow it to continue the previous formatting.